### PR TITLE
Bump version

### DIFF
--- a/staging/networking-benchmarks-for-gRPC/grpc_servers_impl/go/README.md
+++ b/staging/networking-benchmarks-for-gRPC/grpc_servers_impl/go/README.md
@@ -3,8 +3,8 @@
 Outlined below are the instructions to setup the gRPC Go server. 
 
 ## Requirements
-- go v1.19.4 linux/amd64
-- grpc v1.49.0
+- go v1.22.1 linux/amd64
+- grpc v1.62.2
 - ghz v0.110.0
 
 ## General Setup

--- a/staging/networking-benchmarks-for-gRPC/grpc_servers_impl/go/go.mod
+++ b/staging/networking-benchmarks-for-gRPC/grpc_servers_impl/go/go.mod
@@ -1,14 +1,16 @@
 module main
 
-go 1.19
+go 1.22
 
-require google.golang.org/grpc v1.56.3
+require (
+	google.golang.org/grpc v1.62.1
+	google.golang.org/protobuf v1.33.0
+)
 
 require (
 	github.com/golang/protobuf v1.5.3 // indirect
-	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
+	golang.org/x/net v0.20.0 // indirect
+	golang.org/x/sys v0.16.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240123012728-ef4313101c80 // indirect
 )


### PR DESCRIPTION
This PR bumps the version for grpc-go and several related libraries in /grpc_servers_impl/go subproject.